### PR TITLE
Add clinic management API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+**/bin/
+**/obj/
+*.user
+*.vs/

--- a/ClinicManagement.sln
+++ b/ClinicManagement.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{700FCBED-CCE3-4862-91F9-A9882C939DAC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClinicManagement.Api", "src\ClinicManagement.Api\ClinicManagement.Api.csproj", "{067B7D48-0355-4D56-A4AA-BC18B516265C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{067B7D48-0355-4D56-A4AA-BC18B516265C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{067B7D48-0355-4D56-A4AA-BC18B516265C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{067B7D48-0355-4D56-A4AA-BC18B516265C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{067B7D48-0355-4D56-A4AA-BC18B516265C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{067B7D48-0355-4D56-A4AA-BC18B516265C} = {700FCBED-CCE3-4862-91F9-A9882C939DAC}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # CodexSample
-Repo for codex test
+
+This repository now includes a simple clinic management API built with .NET 8 and a vertical slice architecture. The API allows creating patients and appointments and stores data in SQL Server using Entity Framework Core.
+
+## Building
+```
+dotnet build ClinicManagement.sln
+```
+
+## Running
+```
+dotnet run --project src/ClinicManagement.Api
+```

--- a/src/ClinicManagement.Api/ApplicationDbContext.cs
+++ b/src/ClinicManagement.Api/ApplicationDbContext.cs
@@ -1,0 +1,17 @@
+using ClinicManagement.Api.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
+
+    public DbSet<Patient> Patients => Set<Patient>();
+    public DbSet<Appointment> Appointments => Set<Appointment>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/src/ClinicManagement.Api/ClinicManagement.Api.csproj
+++ b/src/ClinicManagement.Api/ClinicManagement.Api.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/ClinicManagement.Api/ClinicManagement.Api.http
+++ b/src/ClinicManagement.Api/ClinicManagement.Api.http
@@ -1,0 +1,6 @@
+@ClinicManagement.Api_HostAddress = http://localhost:5028
+
+GET {{ClinicManagement.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/ClinicManagement.Api/Domain/Appointment.cs
+++ b/src/ClinicManagement.Api/Domain/Appointment.cs
@@ -1,0 +1,10 @@
+namespace ClinicManagement.Api.Domain;
+
+public class Appointment
+{
+    public int Id { get; set; }
+    public DateTime Date { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public int PatientId { get; set; }
+    public Patient? Patient { get; set; }
+}

--- a/src/ClinicManagement.Api/Domain/Patient.cs
+++ b/src/ClinicManagement.Api/Domain/Patient.cs
@@ -1,0 +1,10 @@
+namespace ClinicManagement.Api.Domain;
+
+public class Patient
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTime DateOfBirth { get; set; }
+
+    public ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+}

--- a/src/ClinicManagement.Api/Features/Appointments/AddAppointment.cs
+++ b/src/ClinicManagement.Api/Features/Appointments/AddAppointment.cs
@@ -1,0 +1,25 @@
+using ClinicManagement.Api.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api.Features.Appointments;
+
+public record AddAppointmentCommand(int PatientId, DateTime Date, string Description) : IRequest<int>;
+
+public class AddAppointmentHandler(ApplicationDbContext db) : IRequestHandler<AddAppointmentCommand, int>
+{
+    public async Task<int> Handle(AddAppointmentCommand request, CancellationToken cancellationToken)
+    {
+        var exists = await db.Patients.AnyAsync(p => p.Id == request.PatientId, cancellationToken);
+        if (!exists) return -1;
+        var appointment = new Appointment
+        {
+            PatientId = request.PatientId,
+            Date = request.Date,
+            Description = request.Description
+        };
+        db.Appointments.Add(appointment);
+        await db.SaveChangesAsync(cancellationToken);
+        return appointment.Id;
+    }
+}

--- a/src/ClinicManagement.Api/Features/Appointments/GetAppointments.cs
+++ b/src/ClinicManagement.Api/Features/Appointments/GetAppointments.cs
@@ -1,0 +1,20 @@
+using ClinicManagement.Api.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api.Features.Appointments;
+
+public record GetAppointmentsQuery(int? PatientId) : IRequest<List<Appointment>>;
+
+public class GetAppointmentsHandler(ApplicationDbContext db) : IRequestHandler<GetAppointmentsQuery, List<Appointment>>
+{
+    public async Task<List<Appointment>> Handle(GetAppointmentsQuery request, CancellationToken cancellationToken)
+    {
+        var query = db.Appointments.AsQueryable();
+        if (request.PatientId.HasValue)
+        {
+            query = query.Where(a => a.PatientId == request.PatientId.Value);
+        }
+        return await query.AsNoTracking().ToListAsync(cancellationToken);
+    }
+}

--- a/src/ClinicManagement.Api/Features/Patients/AddPatient.cs
+++ b/src/ClinicManagement.Api/Features/Patients/AddPatient.cs
@@ -1,0 +1,18 @@
+using ClinicManagement.Api.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api.Features.Patients;
+
+public record AddPatientCommand(string Name, DateTime DateOfBirth) : IRequest<int>;
+
+public class AddPatientHandler(ApplicationDbContext db) : IRequestHandler<AddPatientCommand, int>
+{
+    public async Task<int> Handle(AddPatientCommand request, CancellationToken cancellationToken)
+    {
+        var patient = new Patient { Name = request.Name, DateOfBirth = request.DateOfBirth };
+        db.Patients.Add(patient);
+        await db.SaveChangesAsync(cancellationToken);
+        return patient.Id;
+    }
+}

--- a/src/ClinicManagement.Api/Features/Patients/GetPatients.cs
+++ b/src/ClinicManagement.Api/Features/Patients/GetPatients.cs
@@ -1,0 +1,15 @@
+using ClinicManagement.Api.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api.Features.Patients;
+
+public record GetPatientsQuery() : IRequest<List<Patient>>;
+
+public class GetPatientsHandler(ApplicationDbContext db) : IRequestHandler<GetPatientsQuery, List<Patient>>
+{
+    public async Task<List<Patient>> Handle(GetPatientsQuery request, CancellationToken cancellationToken)
+    {
+        return await db.Patients.AsNoTracking().ToListAsync(cancellationToken);
+    }
+}

--- a/src/ClinicManagement.Api/Program.cs
+++ b/src/ClinicManagement.Api/Program.cs
@@ -1,0 +1,39 @@
+using ClinicManagement.Api;
+using ClinicManagement.Api.Features.Appointments;
+using ClinicManagement.Api.Features.Patients;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapPost("/patients", async (AddPatientCommand command, IMediator mediator) =>
+    Results.Ok(await mediator.Send(command)));
+
+app.MapGet("/patients", async (IMediator mediator) =>
+    Results.Ok(await mediator.Send(new GetPatientsQuery())));
+
+app.MapPost("/appointments", async (AddAppointmentCommand command, IMediator mediator) =>
+    Results.Ok(await mediator.Send(command)));
+
+app.MapGet("/appointments", async (int? patientId, IMediator mediator) =>
+    Results.Ok(await mediator.Send(new GetAppointmentsQuery(patientId))));
+
+app.Run();

--- a/src/ClinicManagement.Api/Properties/launchSettings.json
+++ b/src/ClinicManagement.Api/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:3296",
+      "sslPort": 44328
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5028",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7110;http://localhost:5028",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/ClinicManagement.Api/appsettings.Development.json
+++ b/src/ClinicManagement.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Debug"
+    }
+  }
+}

--- a/src/ClinicManagement.Api/appsettings.json
+++ b/src/ClinicManagement.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=ClinicManagement;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
+}


### PR DESCRIPTION
## Summary
- add a vertical slice web API for clinic management
- include patients and appointments features
- provide instructions on building and running the sample

## Testing
- `dotnet build ClinicManagement.sln`


------
https://chatgpt.com/codex/tasks/task_e_6847194ad600832e9306c22b68df6d9e