### PR TITLE
Add patient retrieval by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ dotnet build ClinicManagement.sln
 ## Running
 ```
 dotnet run --project src/ClinicManagement.Api
+```
 
 It includes pages for patient and appointment management as well as simple
 registration and login forms so the UI can grow as the API expands.
+
+## API
+
+### `GET /patients/{id}`
+
+Returns details for a specific patient including any appointments.

--- a/src/ClinicManagement.Api/Features/Patients/GetPatientById.cs
+++ b/src/ClinicManagement.Api/Features/Patients/GetPatientById.cs
@@ -1,0 +1,18 @@
+using ClinicManagement.Api.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api.Features.Patients;
+
+public record GetPatientByIdQuery(int Id) : IRequest<Patient?>;
+
+public class GetPatientByIdHandler(ApplicationDbContext db) : IRequestHandler<GetPatientByIdQuery, Patient?>
+{
+    public async Task<Patient?> Handle(GetPatientByIdQuery request, CancellationToken cancellationToken)
+    {
+        return await db.Patients
+            .AsNoTracking()
+            .Include(p => p.Appointments)
+            .FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
+    }
+}

--- a/src/ClinicManagement.Api/Program.cs
+++ b/src/ClinicManagement.Api/Program.cs
@@ -30,6 +30,9 @@ app.MapPost("/patients", async (AddPatientCommand command, IMediator mediator) =
 app.MapGet("/patients", async (IMediator mediator) =>
     Results.Ok(await mediator.Send(new GetPatientsQuery())));
 
+app.MapGet("/patients/{id:int}", async (int id, IMediator mediator) =>
+    Results.Ok(await mediator.Send(new GetPatientByIdQuery(id))));
+
 app.MapPost("/appointments", async (AddAppointmentCommand command, IMediator mediator) =>
     Results.Ok(await mediator.Send(command)));
 


### PR DESCRIPTION
## Summary
- add `GET /patients/{id}` endpoint
- document new endpoint in README

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_687eef97fa14832eaf1cb4bd2f99b310