### PR TITLE
Add sample React auth client and user features

### DIFF
--- a/samples/react-auth-client/.babelrc
+++ b/samples/react-auth-client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/samples/react-auth-client/README.md
+++ b/samples/react-auth-client/README.md
@@ -1,0 +1,5 @@
+# React Authentication Sample
+
+This directory contains a simple React client that works with the ClinicManagement API to demonstrate login, logout and password change flows.
+
+Run `npm install` then `npm start` to launch the client. It expects the API to be running on `https://localhost:5001`.

--- a/samples/react-auth-client/package.json
+++ b/samples/react-auth-client/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "react-auth-client",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/samples/react-auth-client/public/index.html
+++ b/samples/react-auth-client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>React Auth Sample</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/samples/react-auth-client/src/App.jsx
+++ b/samples/react-auth-client/src/App.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Routes, Route, useNavigate, Link } from 'react-router-dom';
+import Login from './Login';
+import ChangePassword from './ChangePassword';
+
+function App() {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+  const navigate = useNavigate();
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+    navigate('/login');
+  };
+
+  return (
+    <div>
+      <nav>
+        {token && <button onClick={logout}>Logout</button>}
+        {token && <Link to="/change-password">Change Password</Link>}
+      </nav>
+      <Routes>
+        <Route path="/login" element={<Login onLogin={t => { localStorage.setItem('token', t); setToken(t); navigate('/'); }} />} />
+        <Route path="/change-password" element={<ChangePassword />} />
+        <Route path="/" element={<h2>Welcome</h2>} />
+      </Routes>
+    </div>
+  );
+}
+
+export default App;

--- a/samples/react-auth-client/src/ChangePassword.jsx
+++ b/samples/react-auth-client/src/ChangePassword.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { changePassword } from './api';
+
+function ChangePassword() {
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [msg, setMsg] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (next.length < 6) {
+      setMsg('New password must be at least 6 characters');
+      return;
+    }
+    if (next !== confirm) {
+      setMsg('Passwords do not match');
+      return;
+    }
+    const ok = await changePassword(current, next);
+    setMsg(ok ? 'Password changed' : 'Invalid current password');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Current Password</label>
+        <input type="password" value={current} onChange={e => setCurrent(e.target.value)} />
+      </div>
+      <div>
+        <label>New Password</label>
+        <input type="password" value={next} onChange={e => setNext(e.target.value)} />
+      </div>
+      <div>
+        <label>Confirm New Password</label>
+        <input type="password" value={confirm} onChange={e => setConfirm(e.target.value)} />
+      </div>
+      {msg && <div style={{color:'red'}}>{msg}</div>}
+      <button type="submit">Change Password</button>
+    </form>
+  );
+}
+
+export default ChangePassword;

--- a/samples/react-auth-client/src/Login.jsx
+++ b/samples/react-auth-client/src/Login.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { login } from './api';
+
+function Login({ onLogin }) {
+  const [userName, setUserName] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!userName || !password) {
+      setError('Username and password are required');
+      return;
+    }
+    const token = await login(userName, password);
+    if (token) {
+      onLogin(token);
+    } else {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>User Name</label>
+        <input value={userName} onChange={e => setUserName(e.target.value)} />
+      </div>
+      <div>
+        <label>Password</label>
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+      </div>
+      {error && <div style={{color:'red'}}>{error}</div>}
+      <button type="submit">Login</button>
+    </form>
+  );
+}
+
+export default Login;

--- a/samples/react-auth-client/src/api.js
+++ b/samples/react-auth-client/src/api.js
@@ -1,0 +1,27 @@
+const apiUrl = 'https://localhost:5001';
+
+export async function login(userName, password) {
+  const res = await fetch(`${apiUrl}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userName, password })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    return data.token;
+  }
+  return null;
+}
+
+export async function changePassword(currentPassword, newPassword) {
+  const token = localStorage.getItem('token');
+  const res = await fetch(`${apiUrl}/change-password`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify({ currentPassword, newPassword })
+  });
+  return res.ok;
+}

--- a/samples/react-auth-client/src/index.js
+++ b/samples/react-auth-client/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/samples/react-auth-client/webpack.config.js
+++ b/samples/react-auth-client/webpack.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.js', '.jsx']
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public')
+    },
+    port: 3000
+  }
+};

--- a/src/ClinicManagement.Api/ApplicationDbContext.cs
+++ b/src/ClinicManagement.Api/ApplicationDbContext.cs
@@ -9,6 +9,7 @@ public class ApplicationDbContext : DbContext
 
     public DbSet<Patient> Patients => Set<Patient>();
     public DbSet<Appointment> Appointments => Set<Appointment>();
+    public DbSet<User> Users => Set<User>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/ClinicManagement.Api/Domain/User.cs
+++ b/src/ClinicManagement.Api/Domain/User.cs
@@ -1,0 +1,8 @@
+namespace ClinicManagement.Api.Domain;
+
+public class User
+{
+    public int Id { get; set; }
+    public string UserName { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+}

--- a/src/ClinicManagement.Api/Features/Users/ChangePassword.cs
+++ b/src/ClinicManagement.Api/Features/Users/ChangePassword.cs
@@ -1,0 +1,20 @@
+using ClinicManagement.Api.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api.Features.Users;
+
+public record ChangePasswordCommand(int UserId, string CurrentPassword, string NewPassword) : IRequest<bool>;
+
+public class ChangePasswordHandler(ApplicationDbContext db) : IRequestHandler<ChangePasswordCommand, bool>
+{
+    public async Task<bool> Handle(ChangePasswordCommand request, CancellationToken cancellationToken)
+    {
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+        if (user is null) return false;
+        if (!PasswordUtils.VerifyPassword(request.CurrentPassword, user.PasswordHash)) return false;
+        user.PasswordHash = PasswordUtils.HashPassword(request.NewPassword);
+        await db.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/src/ClinicManagement.Api/Features/Users/Login.cs
+++ b/src/ClinicManagement.Api/Features/Users/Login.cs
@@ -1,0 +1,19 @@
+using ClinicManagement.Api.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicManagement.Api.Features.Users;
+
+public record LoginCommand(string UserName, string Password) : IRequest<string?>;
+
+public class LoginHandler(ApplicationDbContext db) : IRequestHandler<LoginCommand, string?>
+{
+    public async Task<string?> Handle(LoginCommand request, CancellationToken cancellationToken)
+    {
+        var user = await db.Users.FirstOrDefaultAsync(u => u.UserName == request.UserName, cancellationToken);
+        if (user is null) return null;
+        if (!PasswordUtils.VerifyPassword(request.Password, user.PasswordHash)) return null;
+        // Normally generate JWT here
+        return "sample-token";
+    }
+}

--- a/src/ClinicManagement.Api/PasswordUtils.cs
+++ b/src/ClinicManagement.Api/PasswordUtils.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ClinicManagement.Api;
+
+public static class PasswordUtils
+{
+    public static string HashPassword(string password)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(password));
+        return Convert.ToHexString(bytes);
+    }
+
+    public static bool VerifyPassword(string password, string hash)
+    {
+        return HashPassword(password) == hash;
+    }
+}

--- a/src/ClinicManagement.Api/Program.cs
+++ b/src/ClinicManagement.Api/Program.cs
@@ -1,6 +1,7 @@
 using ClinicManagement.Api;
 using ClinicManagement.Api.Features.Appointments;
 using ClinicManagement.Api.Features.Patients;
+using ClinicManagement.Api.Features.Users;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,6 +16,21 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    db.Database.EnsureCreated();
+    if (!db.Users.Any())
+    {
+        db.Users.Add(new ClinicManagement.Api.Domain.User
+        {
+            UserName = "admin",
+            PasswordHash = PasswordUtils.HashPassword("Password123")
+        });
+        db.SaveChanges();
+    }
+}
 
 if (app.Environment.IsDevelopment())
 {
@@ -35,5 +51,14 @@ app.MapPost("/appointments", async (AddAppointmentCommand command, IMediator med
 
 app.MapGet("/appointments", async (int? patientId, IMediator mediator) =>
     Results.Ok(await mediator.Send(new GetAppointmentsQuery(patientId))));
+
+app.MapPost("/login", async (LoginCommand command, IMediator mediator) =>
+{
+    var token = await mediator.Send(command);
+    return token is null ? Results.Unauthorized() : Results.Ok(new { token });
+});
+
+app.MapPost("/change-password", async (ChangePasswordCommand command, IMediator mediator) =>
+    await mediator.Send(command) ? Results.Ok() : Results.BadRequest());
 
 app.Run();


### PR DESCRIPTION
## Summary
- add a React client example with login and change password flows
- implement `User` entity, password hashing helpers and endpoints for login and password change
- seed a default `admin` user on startup

## Testing
- `dotnet build ClinicManagement.sln` *(fails: command not found)*
- `npm install` in `samples/react-auth-client`
- `npm run build` in `samples/react-auth-client` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882282f2d54832e911fd69dcf01c200